### PR TITLE
feat: automatically create organisation when user is created

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,21 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
-    "comma-dangle": ["error", "always-multiline"]
+    "comma-dangle": [
+      "error",
+      "always-multiline"
+    ],
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "never"
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1112,6 +1112,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "amqplib": "0.8.0",
     "camelcase-keys": "7.0.0",
     "convict": "6.1.0",
+    "dotenv": "^10.0.0",
     "i18n-iso-countries": "^6.8.0",
     "knex": "0.95.6",
     "morgan": "1.10.0",

--- a/src/apisuite/index.ts
+++ b/src/apisuite/index.ts
@@ -1,7 +1,7 @@
 import config from '../config'
 import fetch from 'node-fetch'
 import log from '../log'
-import {Organization} from "../models/organization";
+import { Organization } from '../models/organization'
 
 
 /**
@@ -9,8 +9,8 @@ import {Organization} from "../models/organization";
  * @param name - Name of the organisation
  */
 export const createOrganisation = async (name: string): Promise<Organization | null> => {
-    const url = new URL(`/organizations`, config.get('apisuite.url'));
-    const body = JSON.stringify({name});
+    const url = new URL('/organizations', config.get('apisuite.url'))
+    const body = JSON.stringify({ name })
 
     try {
         const response = await fetch(url.toString(), {

--- a/src/apisuite/index.ts
+++ b/src/apisuite/index.ts
@@ -10,7 +10,12 @@ import { Organization } from '../models/organization'
  */
 export const createOrganisation = async (name: string): Promise<Organization | null> => {
     const url = new URL('/organizations', config.get('apisuite.url'))
-    const body = JSON.stringify({ name })
+    const body = JSON.stringify({
+        name,
+        options: {
+            selfAssignNewOrganization: false,
+        },
+    })
 
     try {
         const response = await fetch(url.toString(), {
@@ -31,4 +36,23 @@ export const createOrganisation = async (name: string): Promise<Organization | n
     }
 
     return null
+}
+
+/**
+ * Remove organisation  through APISuite
+ * @param orgId - ID of the organisation to remove
+ */
+export const deleteOrganisation = async (orgId: number): Promise<void> => {
+    const url = new URL(`/organizations/${orgId}`, config.get('apisuite.url'))
+    try {
+        await fetch(url.toString(), {
+            method: 'DELETE',
+            headers: {
+                Authorization: `Bearer ${config.get('apisuite.apiKey')}`,
+                'Content-Type': 'application/json',
+            },
+        })
+    } catch (err) {
+        log.error(err, '[deleteOrganisation]')
+    }
 }

--- a/src/apisuite/index.ts
+++ b/src/apisuite/index.ts
@@ -1,0 +1,34 @@
+import config from '../config'
+import fetch from 'node-fetch'
+import log from '../log'
+import {Organization} from "../models/organization";
+
+
+/**
+ * Create a new organisation through APISuite
+ * @param name - Name of the organisation
+ */
+export const createOrganisation = async (name: string): Promise<Organization | null> => {
+    const url = new URL(`/organizations`, config.get('apisuite.url'));
+    const body = JSON.stringify({name});
+
+    try {
+        const response = await fetch(url.toString(), {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${config.get('apisuite.apiKey')}`,
+                'Content-Type': 'application/json',
+            },
+            body,
+        })
+        if (!response || response.status !== 201) {
+            return null
+        }
+
+        return await response.json() as Organization
+    } catch (err) {
+        log.error(err, '[createOrganisation]')
+    }
+
+    return null
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 import convict from 'convict'
 import { schema } from './schema'
-import {config} from "dotenv";
+import { config } from 'dotenv'
 
-config();
+config()
 export default convict(schema)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,6 @@
 import convict from 'convict'
 import { schema } from './schema'
+import {config} from "dotenv";
 
+config();
 export default convict(schema)

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -42,12 +42,6 @@ export const schema = {
             default: '',
             env: 'APISUITE_API_KEY',
         },
-        adminId: {
-            doc: 'APISuite admin user ID',
-            format: String,
-            default: '',
-            env: 'APISUITE_ADMIN_UID',
-        },
     },
     msgBroker: {
         url: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,60 +1,80 @@
 export const schema = {
-  env: {
-    doc: 'The application environment.',
-    format: ['production', 'development', 'test'],
-    default: 'development',
-    env: 'NODE_ENV',
-  },
-  logLevel: {
-    doc: 'Logger verbosity level',
-    format: String,
-    default: 'debug',
-    env: 'LOG_LEVEL',
-  },
-  dbURI: {
-    doc: 'Database connection string',
-    format: String,
-    default: 'postgresql://dbuser:secretpassword@database.server.com:3211/mydb',
-    env: 'DB_URI',
-  },
-  knexDebug: {
-    doc: 'Knex.js debug flag (https://knexjs.org/#Builder-debug)',
-    format: Boolean,
-    default: false,
-    env: 'KNEX_DEBUG',
-  },
-  etlURL: {
-    doc: 'ETL API URL',
-    format: String,
-    default: 'https://etl.proba-v-mep.esa.int',
-    env: 'ETL_API_URL',
-  },
-  msgBroker: {
-    url: {
-      doc: 'APISuite Message Broker URL',
-      format: String,
-      default: 'amqp://mquser:mqpwd@localhost:5672',
-      env: 'MSG_BROKER_URL',
+    env: {
+        doc: 'The application environment.',
+        format: ['production', 'development', 'test'],
+        default: 'development',
+        env: 'NODE_ENV',
     },
-    eventsExchange: {
-      doc: 'APISuite Message Broker Events Exchange name',
-      format: String,
-      default: 'apisuite_events',
-      env: 'RABBITMQ_EVENTS_EXCHANGE',
+    logLevel: {
+        doc: 'Logger verbosity level',
+        format: String,
+        default: 'debug',
+        env: 'LOG_LEVEL',
     },
-    queue: {
-      doc: 'APISuite Message Broker Events Queue',
-      format: String,
-      default: 'custom-ext',
-      env: 'RABBITMQ_QUEUE',
+    dbURI: {
+        doc: 'Database connection string',
+        format: String,
+        default: 'postgresql://dbuser:secretpassword@database.server.com:3211/mydb',
+        env: 'DB_URI',
     },
-  },
-  features: {
-    defaultLabel: {
-      doc: 'Default label to add to all newly created services',
-      format: String,
-      default: 'prototype',
-      env: 'FEAT_DEFAULT_LABEL',
+    knexDebug: {
+        doc: 'Knex.js debug flag (https://knexjs.org/#Builder-debug)',
+        format: Boolean,
+        default: false,
+        env: 'KNEX_DEBUG',
     },
-  },
+    etlURL: {
+        doc: 'ETL API URL',
+        format: String,
+        default: 'https://etl.proba-v-mep.esa.int',
+        env: 'ETL_API_URL',
+    },
+    apisuite: {
+        url: {
+            doc: 'APISuite API URL',
+            format: String,
+            default: 'https://apisuite-dev.proba-v-mep.esa.int',
+            env: 'APISUITE_URL',
+        },
+        apiKey: {
+            doc: 'APISuite API KEY',
+            format: String,
+            default: '',
+            env: 'APISUITE_API_KEY',
+        },
+        adminId: {
+            doc: 'APISuite admin user ID',
+            format: String,
+            default: '',
+            env: 'APISUITE_ADMIN_UID',
+        },
+    },
+    msgBroker: {
+        url: {
+            doc: 'APISuite Message Broker URL',
+            format: String,
+            default: 'amqp://mquser:mqpwd@localhost:5672',
+            env: 'MSG_BROKER_URL',
+        },
+        eventsExchange: {
+            doc: 'APISuite Message Broker Events Exchange name',
+            format: String,
+            default: 'apisuite_events',
+            env: 'RABBITMQ_EVENTS_EXCHANGE',
+        },
+        queue: {
+            doc: 'APISuite Message Broker Events Queue',
+            format: String,
+            default: 'custom-ext',
+            env: 'RABBITMQ_QUEUE',
+        },
+    },
+    features: {
+        defaultLabel: {
+            doc: 'Default label to add to all newly created services',
+            format: String,
+            default: 'prototype',
+            env: 'FEAT_DEFAULT_LABEL',
+        },
+    },
 }

--- a/src/etl/index.ts
+++ b/src/etl/index.ts
@@ -3,29 +3,29 @@ import fetch from 'node-fetch'
 import log from '../log'
 
 export interface VATCheck {
-  vat: number
-  exempt: boolean
+    vat: number
+    exempt: boolean
 }
 
 export const getVatApplicable = async (vat: string, country: string): Promise<VATCheck | null> => {
-  const url = new URL(`/vat/applicable`, config.get('etlURL'))
-  url.searchParams.append('vat', vat)
-  url.searchParams.append('iso', country)
+    const url = new URL('/vat/applicable', config.get('etlURL'))
+    url.searchParams.append('vat', vat)
+    url.searchParams.append('iso', country)
 
-  try {
-    const response = await fetch(url.toString(), { method: 'GET' })
-    if (!response || response.status !== 200) {
-      return null
+    try {
+        const response = await fetch(url.toString(), { method: 'GET' })
+        if (!response || response.status !== 200) {
+            return null
+        }
+
+        const data = await response.json() as VATCheck
+        return {
+            vat: data.vat,
+            exempt: data.exempt,
+        }
+    } catch (err) {
+        log.error(err, '[getVatApplicable]')
     }
 
-    const data = await response.json() as VATCheck
-    return {
-      vat: data.vat,
-      exempt: data.exempt,
-    }
-  } catch (err) {
-    log.error(err, '[getVatApplicable]')
-  }
-
-  return null
+    return null
 }

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -1,51 +1,69 @@
-import { db, OptTransaction } from '../db'
+import {db, OptTransaction} from '../db'
+import config from "../config";
 
 export interface Organization {
-  id: number
-  name: string
-  description: string
-  taxExempt: boolean
-  vat: string
-  addressId: number
+    id: number
+    name: string
+    description: string
+    taxExempt: boolean
+    vat: string
+    addressId: number
 }
 
 export type OrganizationUpdate = Partial<Organization>
 
 export interface Address {
-  id: number
-  address: string
-  postalCode: string
-  city: string
-  country: string
+    id: number
+    address: string
+    postalCode: string
+    city: string
+    country: string
 }
 
 const update = async (trx: OptTransaction, id: number | string, org: OrganizationUpdate): Promise<Organization> => {
-  const _db = trx ? trx : db
+    const _db = trx ? trx : db
 
-  const rows = await _db('organization')
-    .update(org)
-    .where('id', id)
-    .returning('*')
+    const rows = await _db('organization')
+        .update(org)
+        .where('id', id)
+        .returning('*')
 
-  return rows[0]
+    return rows[0]
 }
 
 const getAddress = async (trx: OptTransaction, id: number | string): Promise<Address | null> => {
-  const _db = trx ? trx : db
+    const _db = trx ? trx : db
 
-  const rows = await _db
-    .select()
-    .from('address')
-    .where('id', id)
+    const rows = await _db
+        .select()
+        .from('address')
+        .where('id', id)
 
-  if (rows.length) {
-    return rows[0]
-  }
+    if (rows.length) {
+        return rows[0]
+    }
 
-  return null
+    return null
+}
+
+/**
+ * Update the owner of an organisation that is created by the admin
+ * @param trx - Active transaction details
+ * @param orgId - ID of the organisation to update
+ * @param ownerId - User ID of the new owner for the organisation
+ */
+const updateAdminOrgOwner = async (trx: OptTransaction, orgId: number, ownerId: number): Promise<void> => {
+    const _db = trx ? trx : db
+    await _db('user_organization')
+        .update('user_id', ownerId)
+        .update('current_org', 'true')
+        .where('org_id', orgId)
+        .andWhere('role_id', 4)
+        .andWhere('user_id', config.get('apisuite.adminId'))
 }
 
 export {
-  update,
-  getAddress,
+    update,
+    getAddress,
+    updateAdminOrgOwner,
 }

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -46,18 +46,40 @@ const getAddress = async (trx: OptTransaction, id: number | string): Promise<Add
 }
 
 /**
- * Link a user as the organisation owner to an existing organisation
+ * Retrieve the role id from the database based on its name
+ * @param trx - Active transaction details
+ * @param name - Name of the role
+ */
+const getRoleID = async (trx: OptTransaction, name: string): Promise<number | null> => {
+    const _db = trx ? trx : db
+
+    const rows = await _db
+        .select('id')
+        .from('role')
+        .where('name', name)
+
+    if (rows.length) {
+        return rows[0].id
+    }
+    return null
+}
+
+
+/**
+ * Link a user to an existing organisation
  * @param trx - Active transaction details
  * @param orgId - ID of the organisation to update
  * @param userId - User ID of the new owner for the organisation
+ * @param roleId - ID of the role to assign to the user
  */
-const linkOrganisationToUser = async (trx: OptTransaction, orgId: number, userId: number): Promise<void> => {
+const linkUserToOrganisation = async (trx: OptTransaction, orgId: number, userId: number, roleId: number): Promise<void> => {
     const _db = trx ? trx : db
+
     await _db('user_organization')
         .insert({
             'user_id': userId,
             'org_id': orgId,
-            'role_id': 4,
+            'role_id': roleId,
             'current_org': true,
             'created_at': new Date().toISOString(),
             'updated_at': new Date().toISOString(),
@@ -67,5 +89,6 @@ const linkOrganisationToUser = async (trx: OptTransaction, orgId: number, userId
 export {
     update,
     getAddress,
-    linkOrganisationToUser,
+    getRoleID,
+    linkUserToOrganisation,
 }

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -1,5 +1,5 @@
-import {db, OptTransaction} from '../db'
-import config from "../config";
+import { db, OptTransaction } from '../db'
+import config from '../config'
 
 export interface Organization {
     id: number

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -1,5 +1,4 @@
 import { db, OptTransaction } from '../db'
-import config from '../config'
 
 export interface Organization {
     id: number
@@ -47,23 +46,26 @@ const getAddress = async (trx: OptTransaction, id: number | string): Promise<Add
 }
 
 /**
- * Update the owner of an organisation that is created by the admin
+ * Link a user as the organisation owner to an existing organisation
  * @param trx - Active transaction details
  * @param orgId - ID of the organisation to update
- * @param ownerId - User ID of the new owner for the organisation
+ * @param userId - User ID of the new owner for the organisation
  */
-const updateAdminOrgOwner = async (trx: OptTransaction, orgId: number, ownerId: number): Promise<void> => {
+const linkOrganisationToUser = async (trx: OptTransaction, orgId: number, userId: number): Promise<void> => {
     const _db = trx ? trx : db
     await _db('user_organization')
-        .update('user_id', ownerId)
-        .update('current_org', 'true')
-        .where('org_id', orgId)
-        .andWhere('role_id', 4)
-        .andWhere('user_id', config.get('apisuite.adminId'))
+        .insert({
+            'user_id': userId,
+            'org_id': orgId,
+            'role_id': 4,
+            'current_org': true,
+            'created_at': new Date().toISOString(),
+            'updated_at': new Date().toISOString(),
+        })
 }
 
 export {
     update,
     getAddress,
-    updateAdminOrgOwner,
+    linkOrganisationToUser,
 }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,45 @@
+import {db, OptTransaction} from '../db'
+
+export interface User {
+    id: number
+}
+
+export interface UserInfo {
+    id: number;
+    name: string;
+    email: string;
+    password: string;
+    activation_token: string;
+    created_at: string;
+    updated_at: string;
+    bio: string;
+    avatar: string;
+    mobile: string;
+    last_login: string;
+    oidc_provider: string;
+    oidc_id: string;
+}
+
+/**
+ * Retrieve the user information from the database based on a user ID
+ * @param trx - Active transaction details
+ * @param id - User ID for which to get the details
+ */
+const getUserInfo = async (trx: OptTransaction, id: number | string): Promise<UserInfo | null> => {
+    const _db = trx ? trx : db
+
+    const rows = await _db
+        .select()
+        .from('users')
+        .where('id', id)
+
+    if (rows.length) {
+        return rows[0]
+    }
+
+    return null
+}
+
+export {
+    getUserInfo,
+}

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,4 +1,4 @@
-import {db, OptTransaction} from '../db'
+import { db, OptTransaction } from '../db'
 
 export interface User {
     id: number

--- a/src/msg-broker/consumer.ts
+++ b/src/msg-broker/consumer.ts
@@ -1,9 +1,9 @@
 import amqplib from 'amqplib'
 import log from '../log'
-import {routingKeys} from './types'
-import {handleOrgCreateUpdate, orgMetaToInternal, validateOrgMessage} from './organization'
-import {appMetaToInternal, handleAppCreate, validateAppMessage} from './app'
-import {handleUserCreateOrgCreation, userMessageToInternal, validateUserMessage} from "./user";
+import { routingKeys } from './types'
+import { handleOrgCreateUpdate, orgMetaToInternal, validateOrgMessage } from './organization'
+import { appMetaToInternal, handleAppCreate, validateAppMessage } from './app'
+import { handleUserCreateOrgCreation, userMessageToInternal, validateUserMessage } from './user'
 
 export const onMessage = (data: amqplib.ConsumeMessage | null): void => {
     if (!data || !data.fields || !data.fields.routingKey) {

--- a/src/msg-broker/consumer.ts
+++ b/src/msg-broker/consumer.ts
@@ -1,49 +1,50 @@
 import amqplib from 'amqplib'
 import log from '../log'
-import { routingKeys } from './types'
-import {
-  handleOrgCreateUpdate,
-  orgMetaToInternal,
-  validateOrgMessage,
-} from './organization'
-import {
-  handleAppCreate,
-  validateAppMessage,
-  appMetaToInternal,
-} from './app'
+import {routingKeys} from './types'
+import {handleOrgCreateUpdate, orgMetaToInternal, validateOrgMessage} from './organization'
+import {appMetaToInternal, handleAppCreate, validateAppMessage} from './app'
+import {handleUserCreateOrgCreation, userMessageToInternal, validateUserMessage} from "./user";
 
 export const onMessage = (data: amqplib.ConsumeMessage | null): void => {
-  if (!data || !data.fields || !data.fields.routingKey) {
-    log.error('invalid msg', '[msg broker onMessage]')
-    return
-  }
-
-  try {
-    const msg = JSON.parse(data.content.toString())
-
-    switch (data.fields.routingKey) {
-      case routingKeys.APP_CREATED: {
-        if (!validateAppMessage(msg)) {
-          log.warn('could not update app', msg)
-          break
-        }
-        handleAppCreate(appMetaToInternal(msg.meta))
-          .catch((err) => log.error(err))
-        break
-      }
-      case routingKeys.ORG_UPDATED:
-      case routingKeys.ORG_CREATED: {
-        if (!validateOrgMessage(msg)) {
-          log.warn('could not update organization', msg)
-          break
-        }
-        log.debug(msg)
-        handleOrgCreateUpdate(orgMetaToInternal(msg.meta))
-          .catch((err) => log.error(err))
-        break
-      }
+    if (!data || !data.fields || !data.fields.routingKey) {
+        log.error('invalid msg', '[msg broker onMessage]')
+        return
     }
-  } catch(err) {
-    log.error(err, '[msg broker onMessage]')
-  }
+
+    try {
+        const msg = JSON.parse(data.content.toString())
+        switch (data.fields.routingKey) {
+            case routingKeys.APP_CREATED: {
+                if (!validateAppMessage(msg)) {
+                    log.warn('could not update app', msg)
+                    break
+                }
+                handleAppCreate(appMetaToInternal(msg.meta))
+                    .catch((err) => log.error(err))
+                break
+            }
+            case routingKeys.ORG_UPDATED:
+            case routingKeys.ORG_CREATED: {
+                if (!validateOrgMessage(msg)) {
+                    log.warn('could not update organization', msg)
+                    break
+                }
+                log.debug(msg)
+                handleOrgCreateUpdate(orgMetaToInternal(msg.meta))
+                    .catch((err) => log.error(err))
+                break
+            }
+            case routingKeys.USER_CREATED: {
+                if (!validateUserMessage(msg)) {
+                    log.warn('could not validate user message', msg)
+                    break
+                }
+                handleUserCreateOrgCreation(userMessageToInternal(msg))
+                    .catch((err) => log.error(err))
+                break
+            }
+        }
+    } catch (err) {
+        log.error(err, '[msg broker onMessage]')
+    }
 }

--- a/src/msg-broker/organization.ts
+++ b/src/msg-broker/organization.ts
@@ -1,6 +1,6 @@
 import { db } from '../db'
 import { getAlpha2Code } from 'i18n-iso-countries'
-import { Organization, update, getAddress } from '../models/organization'
+import { getAddress, Organization, update } from '../models/organization'
 import { getVatApplicable } from '../etl'
 
 interface OrganizationMeta {
@@ -40,7 +40,7 @@ export const handleOrgCreateUpdate = async (org: Organization): Promise<void> =>
       return
     }
 
-    const countryCode = getAlpha2Code(address.country, "en")
+    const countryCode = getAlpha2Code(address.country, 'en')
     if (!countryCode) {
       await trx.commit()
       return

--- a/src/msg-broker/types.ts
+++ b/src/msg-broker/types.ts
@@ -2,4 +2,5 @@ export enum routingKeys {
   APP_CREATED = 'api.app.created',
   ORG_CREATED = 'api.organization.created',
   ORG_UPDATED = 'api.organization.updated',
+  USER_CREATED = 'api.user.created'
 }

--- a/src/msg-broker/user.ts
+++ b/src/msg-broker/user.ts
@@ -1,0 +1,48 @@
+import {db} from '../db'
+import {getUserInfo, User, UserInfo} from "../models/user";
+import {Organization, updateAdminOrgOwner} from "../models/organization";
+import {createOrganisation} from "../apisuite";
+import log from '../log'
+
+
+interface UserMessage {
+    user_id: number
+}
+
+export const validateUserMessage = (msg: UserMessage): boolean => {
+    return !!(msg && msg.user_id)
+}
+
+export const userMessageToInternal = (msg: UserMessage): User => ({
+    id: Number(msg.user_id),
+})
+
+export const handleUserCreateOrgCreation = async (user: User): Promise<void> => {
+    const trx = await db.transaction()
+
+    try {
+        // Get the user information based on the incoming message
+        const userInfo: UserInfo | null = await getUserInfo(trx, user.id);
+        if (!userInfo) {
+            log.error(`Could not find user ${user.id}`);
+            await trx.commit()
+            return
+        }
+
+        // Create organisation based on the user's email address
+        const organisation: Organization | null = await createOrganisation(`${userInfo.email}`);
+        if (!organisation) {
+            log.error(`Could not create organisation for user ${userInfo.id}`);
+            await trx.commit()
+            return
+        }
+
+        // Update organisation to set the user as organisation owner
+        await updateAdminOrgOwner(trx, organisation.id, user.id);
+
+        await trx.commit()
+    } catch (err) {
+        log.error(`Error when handling message for automatic creation of organisation for user ${user.id} - ${err}`);
+        await trx.rollback()
+    }
+}

--- a/src/msg-broker/user.ts
+++ b/src/msg-broker/user.ts
@@ -1,7 +1,7 @@
-import {db} from '../db'
-import {getUserInfo, User, UserInfo} from "../models/user";
-import {Organization, updateAdminOrgOwner} from "../models/organization";
-import {createOrganisation} from "../apisuite";
+import { db } from '../db'
+import { getUserInfo, User, UserInfo } from '../models/user'
+import { Organization, updateAdminOrgOwner } from '../models/organization'
+import { createOrganisation } from '../apisuite'
 import log from '../log'
 
 
@@ -22,27 +22,27 @@ export const handleUserCreateOrgCreation = async (user: User): Promise<void> => 
 
     try {
         // Get the user information based on the incoming message
-        const userInfo: UserInfo | null = await getUserInfo(trx, user.id);
+        const userInfo: UserInfo | null = await getUserInfo(trx, user.id)
         if (!userInfo) {
-            log.error(`Could not find user ${user.id}`);
+            log.error(`Could not find user ${user.id}`)
             await trx.commit()
             return
         }
 
         // Create organisation based on the user's email address
-        const organisation: Organization | null = await createOrganisation(`${userInfo.email}`);
+        const organisation: Organization | null = await createOrganisation(`${userInfo.email}`)
         if (!organisation) {
-            log.error(`Could not create organisation for user ${userInfo.id}`);
+            log.error(`Could not create organisation for user ${userInfo.id}`)
             await trx.commit()
             return
         }
 
         // Update organisation to set the user as organisation owner
-        await updateAdminOrgOwner(trx, organisation.id, user.id);
+        await updateAdminOrgOwner(trx, organisation.id, user.id)
 
         await trx.commit()
     } catch (err) {
-        log.error(`Error when handling message for automatic creation of organisation for user ${user.id} - ${err}`);
+        log.error(`Error when handling message for automatic creation of organisation for user ${user.id} - ${err}`)
         await trx.rollback()
     }
 }

--- a/src/msg-broker/user.ts
+++ b/src/msg-broker/user.ts
@@ -1,6 +1,6 @@
 import { db } from '../db'
 import { getUserInfo, User, UserInfo } from '../models/user'
-import { linkOrganisationToUser, Organization } from '../models/organization'
+import { getRoleID, linkUserToOrganisation, Organization } from '../models/organization'
 import { createOrganisation, deleteOrganisation } from '../apisuite'
 import log from '../log'
 
@@ -34,8 +34,14 @@ export const handleUserCreateOrgCreation = async (user: User): Promise<void> => 
             throw new Error(`Could not create organisation for user ${userInfo.id}`)
         }
 
+        // Retrieve the role ID for the organisation owner
+        const roleId: number | null = await getRoleID(trx, 'organizationOwner')
+        if (!roleId) {
+            throw new Error('Could not find organizationOwner role ID')
+        }
+
         // Update organisation to set the user as organisation owner
-        await linkOrganisationToUser(trx, organisation.id, user.id)
+        await linkUserToOrganisation(trx, organisation.id, user.id, roleId)
 
         await trx.commit()
     } catch (err) {


### PR DESCRIPTION
In the context of the billing on organisational level, each user of the marketplace should be part of an organisation. To keep the threshold low for existing and new users of the marketplace, the custom extension could be extended with creating a new organisation for that user automatically upon user creation. This would prevent the additional step of users going to the marketplace and creating an organisation themselves.

The updates in this pull request will execute 3 steps when a user is created:

1. Fetch the user information based on the ID that is provided in the user creation message
2. Create a new organisation through the APISuite backend API with the admin API token. This will make sure that all relevant database tables and other custom flows are triggered. However, this will result in an organisation that is linked to the account that created the API token and not the actual user.
3. Update the `user_organization` table and set the owner of the new organisation to the new user and make sure that the organisation is the current active one of the newly created user.